### PR TITLE
spaces, style and formatters

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,32 +1,26 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-extensions = [
-        'sphinx.ext.autodoc',
-        'jaraco.packaging.sphinx',
-        'rst.linker',
-]
+extensions = ["sphinx.ext.autodoc", "jaraco.packaging.sphinx", "rst.linker"]
 
-master_doc = 'index'
+master_doc = "index"
 
 link_files = {
-        '../CHANGES.rst': dict(
-                using=dict(
-                        GH='https://github.com',
-                ),
-                replace=[
-                        dict(
-                                pattern=r'(Issue #|\B#)(?P<issue>\d+)',
-                                url='{package_url}/issues/{issue}',
-                        ),
-                        dict(
-                                pattern=r'^(?m)((?P<scm_version>v?\d+(\.\d+){1,2}))\n[-=]+\n',
-                                with_scm='{text}\n{rev[timestamp]:%d %b %Y}\n',
-                        ),
-                        dict(
-                                pattern=r'PEP[- ](?P<pep_number>\d+)',
-                                url='https://www.python.org/dev/peps/pep-{pep_number:0>4}/',
-                        ),
-                ],
-        ),
+    "../CHANGES.rst": dict(
+        using=dict(GH="https://github.com"),
+        replace=[
+            dict(
+                pattern=r"(Issue #|\B#)(?P<issue>\d+)",
+                url="{package_url}/issues/{issue}",
+            ),
+            dict(
+                pattern=r"^(?m)((?P<scm_version>v?\d+(\.\d+){1,2}))\n[-=]+\n",
+                with_scm="{text}\n{rev[timestamp]:%d %b %Y}\n",
+            ),
+            dict(
+                pattern=r"PEP[- ](?P<pep_number>\d+)",
+                url="https://www.python.org/dev/peps/pep-{pep_number:0>4}/",
+            ),
+        ],
+    )
 }

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -2,31 +2,31 @@
 # -*- coding: utf-8 -*-
 
 extensions = [
-	'sphinx.ext.autodoc',
-	'jaraco.packaging.sphinx',
-	'rst.linker',
+        'sphinx.ext.autodoc',
+        'jaraco.packaging.sphinx',
+        'rst.linker',
 ]
 
 master_doc = 'index'
 
 link_files = {
-	'../CHANGES.rst': dict(
-		using=dict(
-			GH='https://github.com',
-		),
-		replace=[
-			dict(
-				pattern=r'(Issue #|\B#)(?P<issue>\d+)',
-				url='{package_url}/issues/{issue}',
-			),
-			dict(
-				pattern=r'^(?m)((?P<scm_version>v?\d+(\.\d+){1,2}))\n[-=]+\n',
-				with_scm='{text}\n{rev[timestamp]:%d %b %Y}\n',
-			),
-			dict(
-				pattern=r'PEP[- ](?P<pep_number>\d+)',
-				url='https://www.python.org/dev/peps/pep-{pep_number:0>4}/',
-			),
-		],
-	),
+        '../CHANGES.rst': dict(
+                using=dict(
+                        GH='https://github.com',
+                ),
+                replace=[
+                        dict(
+                                pattern=r'(Issue #|\B#)(?P<issue>\d+)',
+                                url='{package_url}/issues/{issue}',
+                        ),
+                        dict(
+                                pattern=r'^(?m)((?P<scm_version>v?\d+(\.\d+){1,2}))\n[-=]+\n',
+                                with_scm='{text}\n{rev[timestamp]:%d %b %Y}\n',
+                        ),
+                        dict(
+                                pattern=r'PEP[- ](?P<pep_number>\d+)',
+                                url='https://www.python.org/dev/peps/pep-{pep_number:0>4}/',
+                        ),
+                ],
+        ),
 }

--- a/setup.py
+++ b/setup.py
@@ -4,5 +4,5 @@
 
 import setuptools
 
-if __name__ == '__main__':
-        setuptools.setup(use_scm_version=True)
+if __name__ == "__main__":
+    setuptools.setup(use_scm_version=True)

--- a/setup.py
+++ b/setup.py
@@ -5,4 +5,4 @@
 import setuptools
 
 if __name__ == '__main__':
-	setuptools.setup(use_scm_version=True)
+        setuptools.setup(use_scm_version=True)


### PR DESCRIPTION
Since the merge of the skeleton into `jaraco.postgres` the flake8 tests in that project failed again, so I addressed that here. I've configured vim to use `black` as the default formatter, but I was uncertain if that adoption stick to this project, so I used my former tool `autopep8`. Interestingly, they produced the same output.

I believe the changes here should fix the tests in `jaraco.postgres`