### PR TITLE
Require toml extra for setuptools_scm

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=42", "wheel", "setuptools_scm[toml]>=3.4"]
+requires = ["setuptools>=42", "wheel", "setuptools_scm[toml]>=3.4.1"]
 build-backend = "setuptools.build_meta"
 
 [tool.black]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=42", "wheel", "setuptools_scm>=3.4"]
+requires = ["setuptools>=42", "wheel", "setuptools_scm[toml]>=3.4"]
 build-backend = "setuptools.build_meta"
 
 [tool.black]

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,7 +18,7 @@ packages = find:
 include_package_data = true
 python_requires = >=3.6
 install_requires =
-setup_requires = setuptools_scm >= 3.4
+setup_requires = setuptools_scm[toml] >= 3.4
 
 [options.extras_require]
 testing =

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,7 +18,7 @@ packages = find:
 include_package_data = true
 python_requires = >=3.6
 install_requires =
-setup_requires = setuptools_scm[toml] >= 3.4
+setup_requires = setuptools_scm[toml] >= 3.4.1
 
 [options.extras_require]
 testing =


### PR DESCRIPTION
setuptools_scm does not know to invoke itself
if it can't read pyproject.toml.  This broke
sdist installs for projects deriving from skeleton:

```
$ python -m pip install zipp --no-binary zipp
Collecting zipp
  [...]
Successfully installed zipp-0.0.0
```

Note the version number defaulting to '0.0.0'.
Building locally only works because pep517,
the build tool, depends on toml which it exposes
to the build environment.