### PR TITLE
tox: guard against parallel pytest coverage execution

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,5 +1,6 @@
 [run]
 omit = .tox/*
+parallel = true
 
 [report]
 show_missing = True

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,6 @@
 [pytest]
 norecursedirs=dist build .tox .eggs
-addopts=--doctest-modules --flake8 --black --cov
+addopts=--doctest-modules --flake8 --black --cov --cov-append
 doctest_optionflags=ALLOW_UNICODE ELLIPSIS
 filterwarnings=
     # https://github.com/pytest-dev/pytest/issues/6928

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,6 +23,7 @@ setup_requires = setuptools_scm[toml] >= 3.4.1
 [options.extras_require]
 testing =
 	# upstream
+	coverage < 5
 	pytest >= 3.5, !=3.7.3
 	pytest-checkdocs >= 1.2.3
 	pytest-flake8

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = python
+envlist = clean,python
 minversion = 3.2
 # https://github.com/jaraco/skeleton/issues/6
 tox_pip_extensions_ext_venv_update = true
@@ -14,8 +14,16 @@ deps =
 pip_version = pip
 commands =
 	pytest {posargs}
+depends =
+	clean
 usedevelop = True
 extras = testing
+
+[testenv:clean]
+deps = coverage
+depends =
+skip_install = true
+commands = coverage erase
 
 [testenv:docs]
 extras =

--- a/tox.ini
+++ b/tox.ini
@@ -20,7 +20,7 @@ usedevelop = True
 extras = testing
 
 [testenv:clean]
-deps = coverage
+deps = coverage<5
 depends =
 skip_install = true
 commands = coverage erase


### PR DESCRIPTION
An usual problem users have is that pytest-cov will erase the
previous coverage data by default, thus if you run tox with
multiple environments you’ll get incomplete coverage at the end.

To prevent this problem you need to use --cov-append. It’s still
recommended to clean the previous coverage data to have
consistent output.

Cf. https://pytest-cov.readthedocs.io/en/latest/tox.html