### PR TITLE
Use license_files instead of license_file in meta

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,6 @@
 [metadata]
-license_file = LICENSE
+license_files =
+	LICENSE
 name = skeleton
 author = Jason R. Coombs
 author_email = jaraco@jaraco.com


### PR DESCRIPTION
Singular `license_file` is deprecated since wheel v0.32.0.

Refs:
* https://wheel.readthedocs.io/en/stable/news.html
* https://wheel.readthedocs.io/en/stable/user_guide.html#including-license-files-in-the-generated-wheel-file