### PR TITLE
Make sphinx fail on any warnings

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -24,3 +24,6 @@ link_files = {
         ],
     )
 }
+
+# Be strict about any broken references:
+nitpicky = True

--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,7 @@ extras =
 	testing
 changedir = docs
 commands =
-	python -m sphinx . {toxinidir}/build/html
+	python -m sphinx -W --keep-going . {toxinidir}/build/html
 
 [testenv:release]
 skip_install = True


### PR DESCRIPTION
This change adds `nitpicky=True` (which is an equivalent of `-n`) to
make Sphinx emit warnings for any references to non-existing targets.
Then, it adds `-W` to make it fail whenever a single warning is seen.
Finally, `--keep-going` allows Sphinx to print out all the warnings
before exiting instead of showing just one and bailing.

Resolves #29

Refs:
* https://www.sphinx-doc.org/en/master/man/sphinx-build.html#cmdoption-sphinx-build-n
* https://www.sphinx-doc.org/en/master/man/sphinx-build.html#cmdoption-sphinx-build-W
* https://www.sphinx-doc.org/en/master/man/sphinx-build.html#cmdoption-sphinx-build-keep-going