### PR TITLE
Added .templateMarker

### DIFF
--- a/.github/.templateMarker
+++ b/.github/.templateMarker
@@ -1,0 +1,1 @@
+jaraco/skeleton


### PR DESCRIPTION
Proposal: to use the file with this name to track usage of the template and maybe distribute updates to the repos using it via a special bot in future.

While GH has a feature to mark a repo as a template, it has drawbacks that
* there is no way to get all the repos using the template;
* it is not possible to mark an existing repo as the one using the template without deletion of the repo (this way nuking all the issues, disconnecting it from fork network, and having all the stars disappeared). So marking an existing repo this way is completely useless.

Creating a file with a special name solves such issues.
* though I haven't figured out how to search by a file with such an extension (it seems GH lacks such a feature currently, though it has a feature of searching by a programming language, I wonder if such a file can be declared an own programming language), surely search results can be filtered client-side;
* adding and removing of a file can be done without repo recreation.

Also:
* it is not locked to GitHub, so this kind of searches can be done on other platforms too.