### PR TITLE
Add more project urls to setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -5,6 +5,11 @@ author_email = jaraco@jaraco.com
 description = skeleton
 long_description = file:README.rst
 url = https://github.com/jaraco/skeleton
+project_urls =
+    Documentation = https://blog.jaraco.com/a-project-skeleton-for-python-projects/
+    Source Code = https://github.com/jaraco/skeleton
+    Issue Tracker = https://github.com/jaraco/skeleton/issues
+	Changes = https://github.com/jaraco/skeleton/blob/main/CHANGES.rst
 classifiers =
 	Development Status :: 5 - Production/Stable
 	Intended Audience :: Developers


### PR DESCRIPTION
The set of urls which have special handling on pypi can be found in the warehouse repo:
https://github.com/pypa/warehouse/blob/main/warehouse/templates/packaging/detail.html#L20-L60

Fixes #52.