### PR TITLE
Inject check job into CI workflow as ultimate flag

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,8 +27,23 @@ jobs:
       - name: Run tests
         run: tox
 
+  check:  # This job does nothing and is only used for the branch protection
+    if: always()
+
+    needs:
+    - test
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Decide whether the needed jobs succeeded or failed
+      uses: re-actors/alls-green@release/v1
+      with:
+        jobs: ${{ toJSON(needs) }}
+
   release:
-    needs: test
+    needs:
+    - check
     if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
This patch adds a job that is able to accurately signal whether
all the expectations of the required jobs to succeed are met.

This job can then be used as a source of truth for judging whether
"CI passes" and can be used in the branch protection. It also plays
a role of a convenient "gate" — this is the only job that would have
to be listed in the branch protection as opposed to listing every
single job name generated by the test matrix (and they all have
different names — it's not possible to just select one `test` job
name).

Ref: https://github.com/re-actors/alls-green#why