### PR TITLE
Ignore flake8/black warnings with 7.0.1

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -9,7 +9,9 @@ filterwarnings=
 	# shopkeep/pytest-black#55
 	ignore:<class 'pytest_black.BlackItem'> is not using a cooperative constructor:pytest.PytestDeprecationWarning
 	ignore:The \(fspath. py.path.local\) argument to BlackItem is deprecated.:pytest.PytestDeprecationWarning
+	ignore:BlackItem is an Item subclass and should not be a collector:pytest.PytestWarning
 
 	# tholo/pytest-flake8#83
 	ignore:<class 'pytest_flake8.Flake8Item'> is not using a cooperative constructor:pytest.PytestDeprecationWarning
 	ignore:The \(fspath. py.path.local\) argument to Flake8Item is deprecated.:pytest.PytestDeprecationWarning
+	ignore:Flake8Item is an Item subclass and should not be a collector:pytest.PytestWarning


### PR DESCRIPTION
With the release of Pytest 7.0.1, 2 other warnings with `pytest-flake8` and `pytest-black` can make tests fail, when using `-Werror`.

This PR adds the warnings I could find to the ignore filter in `pytest.ini`.

This affects `setuptools` CI workflows.