### PR TITLE
exclude build env from cov reporting

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -2,7 +2,7 @@
 omit =
 	# leading `*/` for pytest-dev/pytest-cov#456
 	*/.tox/*
-        */pep517-build-env-*
+	*/pep517-build-env-*
 
 [report]
 show_missing = True

--- a/.coveragerc
+++ b/.coveragerc
@@ -2,6 +2,7 @@
 omit =
 	# leading `*/` for pytest-dev/pytest-cov#456
 	*/.tox/*
+        */pep517-build-env-*
 
 [report]
 show_missing = True


### PR DESCRIPTION
coverage is hunting around in there (see https://github.com/python/importlib_metadata/runs/5617691032?check_suite_focus=true for example)