### PR TITLE
Update base URL for PEPs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -19,7 +19,7 @@ link_files = {
             ),
             dict(
                 pattern=r'PEP[- ](?P<pep_number>\d+)',
-                url='https://www.python.org/dev/peps/pep-{pep_number:0>4}/',
+                url='https://peps.python.org/pep-{pep_number:0>4}/',
             ),
         ],
     )


### PR DESCRIPTION
PEPs are now at URLs like `https://peps.python.org/pep-0008/` rather than `https://www.python.org/dev/peps/pep-0008/`

The old ones redirect to the new ones, but good to update the links too.