### PR TITLE
🎨 Make the GHA log clean and colorized

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,20 +3,30 @@ name: tests
 on: [push, pull_request]
 
 env:
-  FORCE_COLOR: 1  # Request colored output from CLI tools supporting it
-  MYPY_FORCE_COLOR: 1  # MyPy's color enforcement
-  PIP_DISABLE_PIP_VERSION_CHECK: 1
-  PIP_NO_PYTHON_VERSION_WARNING: 1
-  PIP_NO_WARN_SCRIPT_LOCATION: 1
-  PY_COLORS: 1  # Recognized by the `py` package, dependency of `pytest`
-  TOX_PARALLEL_NO_SPINNER: 1
-  TOX_TESTENV_PASSENV: >-  # Make tox-wrapped tools see color requests
+  # Environment variables to support color support (jaraco/skeleton#66):
+  # Request colored output from CLI tools supporting it
+  FORCE_COLOR: 1
+  # MyPy's color enforcement
+  MYPY_FORCE_COLOR: 1
+  # Recognized by the `py` package, dependency of `pytest`
+  PY_COLORS: 1
+  # Make tox-wrapped tools see color requests
+  TOX_TESTENV_PASSENV: >-
     FORCE_COLOR
     MYPY_FORCE_COLOR
     NO_COLOR
     PY_COLORS
     PYTEST_THEME
     PYTEST_THEME_MODE
+
+  # Suppress noisy pip warnings
+  PIP_DISABLE_PIP_VERSION_CHECK: 1
+  PIP_NO_PYTHON_VERSION_WARNING: 1
+  PIP_NO_WARN_SCRIPT_LOCATION: 1
+
+  # Disable the spinner, noise in GHA; TODO(webknjaz): Fix this upstream
+  TOX_PARALLEL_NO_SPINNER: 1
+
 
 jobs:
   test:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,6 +2,22 @@ name: tests
 
 on: [push, pull_request]
 
+env:
+  FORCE_COLOR: 1  # Request colored output from CLI tools supporting it
+  MYPY_FORCE_COLOR: 1  # MyPy's color enforcement
+  PIP_DISABLE_PIP_VERSION_CHECK: 1
+  PIP_NO_PYTHON_VERSION_WARNING: 1
+  PIP_NO_WARN_SCRIPT_LOCATION: 1
+  PY_COLORS: 1  # Recognized by the `py` package, dependency of `pytest`
+  TOX_PARALLEL_NO_SPINNER: 1
+  TOX_TESTENV_PASSENV: >-  # Make tox-wrapped tools see color requests
+    FORCE_COLOR
+    MYPY_FORCE_COLOR
+    NO_COLOR
+    PY_COLORS
+    PYTEST_THEME
+    PYTEST_THEME_MODE
+
 jobs:
   test:
     strategy:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,13 +3,13 @@ name: tests
 on: [push, pull_request]
 
 env:
-  # Environment variables to support color support (jaraco/skeleton#66):
+  # Color support (jaraco/skeleton#66)
   # Request colored output from CLI tools supporting it
-  FORCE_COLOR: 1
+  FORCE_COLOR: true
   # MyPy's color enforcement
-  MYPY_FORCE_COLOR: 1
+  MYPY_FORCE_COLOR: true
   # Recognized by the `py` package, dependency of `pytest`
-  PY_COLORS: 1
+  PY_COLORS: true
   # Make tox-wrapped tools see color requests
   TOX_TESTENV_PASSENV: >-
     FORCE_COLOR
@@ -20,12 +20,12 @@ env:
     PYTEST_THEME_MODE
 
   # Suppress noisy pip warnings
-  PIP_DISABLE_PIP_VERSION_CHECK: 1
-  PIP_NO_PYTHON_VERSION_WARNING: 1
-  PIP_NO_WARN_SCRIPT_LOCATION: 1
+  PIP_DISABLE_PIP_VERSION_CHECK: true
+  PIP_NO_PYTHON_VERSION_WARNING: true
+  PIP_NO_WARN_SCRIPT_LOCATION: true
 
   # Disable the spinner, noise in GHA; TODO(webknjaz): Fix this upstream
-  TOX_PARALLEL_NO_SPINNER: 1
+  TOX_PARALLEL_NO_SPINNER: true
 
 
 jobs:


### PR DESCRIPTION
This patch sets up root-level environment variables shared by all the workflow jobs. They include:

* Disabling undesired `pip`'s warnings/suggestions
* Requesting the executed apps color their output unconditionally
* Letting `tox` pass those requests to underlying/wrapped programs