### PR TITLE
Make substitution fields more prominent and distinct from true 'skeleton' references

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,18 +1,18 @@
-.. image:: https://img.shields.io/pypi/v/skeleton.svg
-   :target: https://pypi.org/project/skeleton
+.. image:: https://img.shields.io/pypi/v/PROJECT.svg
+   :target: https://pypi.org/project/PROJECT
 
-.. image:: https://img.shields.io/pypi/pyversions/skeleton.svg
+.. image:: https://img.shields.io/pypi/pyversions/PROJECT.svg
 
-.. image:: https://github.com/jaraco/skeleton/workflows/tests/badge.svg
-   :target: https://github.com/jaraco/skeleton/actions?query=workflow%3A%22tests%22
+.. image:: https://github.com/PROJECT_PATH/workflows/tests/badge.svg
+   :target: https://github.com/PROJECT_PATH/actions?query=workflow%3A%22tests%22
    :alt: tests
 
 .. image:: https://img.shields.io/badge/code%20style-black-000000.svg
    :target: https://github.com/psf/black
    :alt: Code style: Black
 
-.. .. image:: https://readthedocs.org/projects/skeleton/badge/?version=latest
-..    :target: https://skeleton.readthedocs.io/en/latest/?badge=latest
+.. .. image:: https://readthedocs.org/projects/PROJECT_RTD/badge/?version=latest
+..    :target: https://PROJECT_RTD.readthedocs.io/en/latest/?badge=latest
 
 .. image:: https://img.shields.io/badge/skeleton-2023-informational
    :target: https://blog.jaraco.com/skeleton

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -7,7 +7,7 @@ Welcome to |project| documentation!
    history
 
 
-.. automodule:: skeleton
+.. automodule:: PROJECT
     :members:
     :undoc-members:
     :show-inheritance:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,10 +1,10 @@
 [metadata]
-name = skeleton
+name = PROJECT
 author = Jason R. Coombs
 author_email = jaraco@jaraco.com
-description = skeleton
+description = PROJECT_DESCRIPTION
 long_description = file:README.rst
-url = https://github.com/jaraco/skeleton
+url = https://github.com/PROJECT_PATH
 classifiers =
 	Development Status :: 5 - Production/Stable
 	Intended Audience :: Developers


### PR DESCRIPTION
In this change, I'm pondering making the fields more prominent.

I have to say, I'm not excited about the prospect of all of the merge conflicts this will create, so I'll almost certainly not merge it until I have confidence I can automate the resolution of merge conflicts. In https://github.com/jaraco/jaraco.develop/blob/66be40935bbe0904999d035c05f4bdccd1a7d89d/jaraco/develop/merge.py#L69-L73, I've had some success with mechanized resolution.