### PR TITLE
Set Permissions for Github Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,6 +2,9 @@ name: tests
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 env:
   # Environment variables to support color support (jaraco/skeleton#66):
   # Request colored output from CLI tools supporting it. Different tools
@@ -104,6 +107,8 @@ jobs:
         jobs: ${{ toJSON(needs) }}
 
   release:
+    permissions:
+      contents: write
     needs:
     - check
     if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')


### PR DESCRIPTION
Hi, I'm opening this PR as suggested at https://github.com/pypa/setuptools/issues/3830

I've set the top level permission to be contents: read and the release job to be the only job to have contents: write permission.

I tried to test it but it seems that the action is not working properly so the same error that is happening in the main repo is happening in my fork.

But I believe the permissions are enough for what the workflow do, let me know if you have any doubts or concerns about it.