### PR TITLE
Adopt towncrier for managing changelog. Fixes jaraco/skeleton#83.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -9,7 +9,7 @@ html_theme = "furo"
 # Link dates and other references in the changelog
 extensions += ['rst.linker']
 link_files = {
-    '../CHANGES.rst': dict(
+    '../NEWS.rst': dict(
         using=dict(GH='https://github.com'),
         replace=[
             dict(

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -5,4 +5,4 @@
 History
 *******
 
-.. include:: ../CHANGES (links).rst
+.. include:: ../NEWS (links).rst

--- a/towncrier.toml
+++ b/towncrier.toml
@@ -1,0 +1,2 @@
+[tool.towncrier]
+title_format = "{version}"

--- a/tox.ini
+++ b/tox.ini
@@ -25,6 +25,15 @@ commands =
 	python -m sphinx -W --keep-going . {toxinidir}/build/html
 	python -m sphinxlint
 
+[testenv:finalize]
+skip_install = True
+deps =
+	towncrier
+	jaraco.develop
+passenv = *
+commands =
+	python -m jaraco.develop.towncrier build
+
 [testenv:release]
 skip_install = True
 deps =


### PR DESCRIPTION
Renamed CHANGES.rst to NEWS.rst to align with towncrier defaults.
