### PR TITLE
tox.ini: call pytest indirectly

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ deps =
 setenv =
 	PYTHONWARNDEFAULTENCODING = 1
 commands =
-	pytest {posargs}
+	python -m pytest {posargs}
 usedevelop = True
 extras =
 	testing


### PR DESCRIPTION
See https://github.com/jaraco/backports.entry_points_selectable/pull/8