### PR TITLE
Tweak coverage configuration for type checking

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -7,6 +7,6 @@ disable_warnings =
 
 [report]
 show_missing = True
-exclude_lines =
+exclude_also =
 	@overload
 	if TYPE_CHECKING:

--- a/.coveragerc
+++ b/.coveragerc
@@ -8,5 +8,6 @@ disable_warnings =
 [report]
 show_missing = True
 exclude_also =
+	# jaraco/skeleton#97
 	@overload
 	if TYPE_CHECKING:

--- a/.coveragerc
+++ b/.coveragerc
@@ -7,3 +7,6 @@ disable_warnings =
 
 [report]
 show_missing = True
+exclude_lines =
+	@overload
+	if TYPE_CHECKING:


### PR DESCRIPTION
I am planning on adding type hints in various jaraco projects that use skeleton. Merging this will cancel out https://github.com/jaraco/jaraco.classes/pull/10/commits/e9788e8109b13e1badae96b5c28abe3eee9ab84a and possibly many other identical commits.