### PR TITLE
ruff: extended-ignore → ignore

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -1,5 +1,5 @@
 [lint]
-extend-ignore = [
+ignore = [
 	# https://docs.astral.sh/ruff/formatter/#conflicting-lint-rules
 	"W191",
 	"E111",


### PR DESCRIPTION
Applies [Repo-Review](https://learn.scientific-python.org/development/guides/repo-review/?repo=jaraco%2Fskeleton&branch=main) suggestion:
* RF201: Avoid using deprecated config settings
  `extend-ignore` deprecated, use `ignore` instead (identical)

See https://docs.astral.sh/ruff/settings/#extend-ignore.