### PR TITLE
ruff: `lint.ignore` → `ignore`

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -1,4 +1,3 @@
-[lint]
 ignore = [
 	# https://docs.astral.sh/ruff/formatter/#conflicting-lint-rules
 	"W191",


### PR DESCRIPTION
`ignore` is part of the [**Top-level**](https://docs.astral.sh/ruff/settings/#top-level) [Ruff Settings](https://docs.astral.sh/ruff/settings/).

I am sorry for missing that in my previous PR.