### PR TITLE
Ignore simple TYPE_CHECKING blocks from coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -7,3 +7,6 @@ disable_warnings =
 
 [report]
 show_missing = True
+exclude_lines = 
+    pragma: no cover
+    if TYPE_CHECKING:

--- a/.coveragerc
+++ b/.coveragerc
@@ -7,6 +7,5 @@ disable_warnings =
 
 [report]
 show_missing = True
-exclude_lines = 
-    pragma: no cover
+exclude_also = 
     if TYPE_CHECKING:


### PR DESCRIPTION
See https://github.com/nedbat/coveragepy/issues/831#issuecomment-517778185 and https://coverage.readthedocs.io/en/latest/excluding.html#advanced-exclusion