### PR TITLE
Apply `preview` setting to ruff formatter

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -18,5 +18,6 @@ ignore = [
 ]
 
 [format]
+preview = true
 # https://docs.astral.sh/ruff/settings/#format-quote-style
 quote-style = "preserve"


### PR DESCRIPTION
It is currently required by the following setting:
```toml
quote-style = "preserve"
```
From https://docs.astral.sh/ruff/settings/#format-quote-style:
> * `preserve` (preview only): Keeps the existing quote character. We don't recommend using this option except for projects that already use a mixture of single and double quotes and can't migrate to using double or single quotes.

Fixes https://github.com/jaraco/skeleton/pull/99#discussion_r1465308024.