### PR TITLE
Allow mypy on PyPy

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -23,9 +23,7 @@ testing =
 	pytest >= 6
 	pytest-checkdocs >= 2.4
 	pytest-cov
-	pytest-mypy; \
-		# workaround for jaraco/skeleton#22
-		python_implementation != "PyPy"
+	pytest-mypy
 	pytest-enabler >= 2.2
 	pytest-ruff >= 0.2.1
 


### PR DESCRIPTION
https://github.com/pypa/setuptools/pull/4257 shows that mypy now installs and runs on PyPy, granted there's no invalid top-of-the-file `# type: ignore` comment like in https://github.com/abravalheri/validate-pyproject/pull/159 .
It could be that mypy 1.5 dropped Python 3.7 and updated their AST.