### PR TITLE
Add a missing semicolon in the GHA workflow trigger

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,7 @@ on:
     branches-ignore:
     # temporary GH branches relating to merge queues (jaraco/skeleton#93)
     - gh-readonly-queue/**
-    tags
+    tags:
     # required if branches-ignore is supplied (jaraco/skeleton#103)
     - '**'
   pull_request:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,8 +4,11 @@ on:
   merge_group:
   push:
     branches-ignore:
-    # disabled for jaraco/skeleton#103
-    # - gh-readonly-queue/**  # Temporary merge queue-related GH-made branches
+    # temporary GH branches relating to merge queues (jaraco/skeleton#93)
+    - gh-readonly-queue/**
+    tags
+    # required if branches-ignore is supplied (jaraco/skeleton#103)
+    - '**'
   pull_request:
 
 permissions:


### PR DESCRIPTION
It's a hotfix for https://github.com/jaraco/skeleton/commit/9e09c1993809435deb6f7a962ed9ae00bf7d80bb