### PR TITLE
These keys must be kept in sync

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -1,3 +1,6 @@
+# keep in sync with `options.requires-python` in `setup.cfg`
+target-version = "py38"
+
 [lint]
 extend-select = [
 	"C901",

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,6 +14,7 @@ classifiers =
 
 [options]
 include_package_data = true
+# keep in sync with `target-version` in `ruff.toml`
 python_requires = >=3.8
 install_requires =
 


### PR DESCRIPTION
If `ruff.toml` exists, the `requires-python` key is currently not taken into account - not in `pyproject.toml` and even less in `setup.cfg`.

See:
https://github.com/astral-sh/ruff/issues/10299

Fixes #119.