### PR TITLE
Update pyproject.tomlpytest-ruff to 0.3.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ testing = [
 	"pytest-cov",
 	"pytest-mypy",
 	"pytest-enabler >= 2.2",
-	"pytest-ruff >= 0.2.1",
+	"pytest-ruff >= 0.3.2",
 
 	# local
 ]


### PR DESCRIPTION
https://github.com/businho/pytest-ruff/releases/tag/v0.3.2 should have a much cleaner error output now