### PR TITLE
Fix dotfiles note indent level

### DIFF
--- a/index.md
+++ b/index.md
@@ -209,7 +209,7 @@ See [gitignore docs](https://git-scm.com/docs/gitignore) for more details regard
 wget https://raw.githubusercontent.com/jaraco/dotfiles/main/.gitignore_global -O - >> .git/info/exclude
 ```
 
-    Note: See [dotfiles](https://docs.github.com/en/codespaces/setting-your-user-preferences/personalizing-github-codespaces-for-your-account#dotfiles) for guidance on applying these settings in GitHub Codespaces.
+Note: See [dotfiles](https://docs.github.com/en/codespaces/setting-your-user-preferences/personalizing-github-codespaces-for-your-account#dotfiles) for guidance on applying these settings in GitHub Codespaces.
 
 # Challenges
 


### PR DESCRIPTION
I tried to look for admonitions that Jekyll could maybe provide OOTB, like GitHub's

> [!Note]
> "alert" admonitions,

but I haven't found anything that doesn't require a custom theme.

Admonitions from GitHub (and other flavors), sadly, [aren't rendered in Jekyll-based pages](https://bswck.github.io/pages-test), so aren't they in the skeleton article.