### PR TITLE
Add Protocols, remove @overload, from `.coveragerc` `exclude_also`

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -9,5 +9,6 @@ disable_warnings =
 show_missing = True
 exclude_also =
 	# jaraco/skeleton#97
-	@overload
+	# These are taken from https://coverage.readthedocs.io/en/latest/excluding.html#advanced-exclusion
+	class .*\bProtocol\):
 	if TYPE_CHECKING:

--- a/.coveragerc
+++ b/.coveragerc
@@ -8,7 +8,8 @@ disable_warnings =
 [report]
 show_missing = True
 exclude_also =
-	# jaraco/skeleton#97
-	# These are taken from https://coverage.readthedocs.io/en/latest/excluding.html#advanced-exclusion
+	# Exclude common false positives per
+	# https://coverage.readthedocs.io/en/latest/excluding.html#advanced-exclusion
+	# Ref jaraco/skeleton#97 and jaraco/skeleton#135
 	class .*\bProtocol\):
 	if TYPE_CHECKING:


### PR DESCRIPTION
By the nature of `: ...` (elipsis on same line as declaration) being ignored by coverage, overloads and *most* Protocol methods are already ignored.

There is one case not ignored out of the box, and it's when `...` is on its own line, like so (docstring means that can't be autofixed by formatters):
```py
class MyClass(Protocol):
    def proto_method(self):
        """some docstring"""
        ...
```

In this PR, I currently ignore Protocols completely, as that's the example given in https://coverage.readthedocs.io/en/latest/excluding.html#advanced-exclusion , but I think it would work just as well to use `^\s+\.\.\.` as mentioned here: https://github.com/nedbat/coveragepy/issues/1476#issuecomment-1284726325 . I'll leave the preference up to you (maybe you want to exclude them all, including `@overload` just in case 🤷 )

Test of these changes on setuptools: https://github.com/pypa/setuptools/pull/4464

Prevents supposed (false-positive) loss of coverage in https://github.com/pypa/setuptools/pull/4192