### PR TITLE
Split the test dependencies into four classes (test, cover, type, check).

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,14 +28,10 @@ Source = "https://github.com/PROJECT_PATH"
 test = [
 	# upstream
 	"pytest >= 6, != 8.1.*",
-	"pytest-checkdocs >= 2.4",
-	"pytest-cov",
-	"pytest-mypy",
-	"pytest-enabler >= 2.2",
-	"pytest-ruff >= 0.2.1; sys_platform != 'cygwin'",
 
 	# local
 ]
+
 doc = [
 	# upstream
 	"sphinx >= 3.5",
@@ -46,5 +42,24 @@ doc = [
 
 	# local
 ]
+
+enabler = [
+	"pytest-enabler >= 2.2",
+]
+
+check = [
+	"pytest-checkdocs >= 2.4",
+	"pytest-ruff >= 0.2.1; sys_platform != 'cygwin'",
+]
+
+cover = [
+	"pytest-cov",
+]
+
+type = [
+	"pytest-mypy",
+]
+
+
 
 [tool.setuptools_scm]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,10 +43,6 @@ doc = [
 	# local
 ]
 
-enabler = [
-	"pytest-enabler >= 2.2",
-]
-
 check = [
 	"pytest-checkdocs >= 2.4",
 	"pytest-ruff >= 0.2.1; sys_platform != 'cygwin'",
@@ -54,6 +50,10 @@ check = [
 
 cover = [
 	"pytest-cov",
+]
+
+enabler = [
+	"pytest-enabler >= 2.2",
 ]
 
 type = [

--- a/tox.ini
+++ b/tox.ini
@@ -8,10 +8,10 @@ commands =
 usedevelop = True
 extras =
 	test
-	cover
-	type
 	check
+	cover
 	enabler
+	type
 
 [testenv:diffcov]
 description = run tests and check that diff from main is covered

--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,10 @@ commands =
 usedevelop = True
 extras =
 	test
+	cover
+	type
+	check
+	enabler
 
 [testenv:diffcov]
 description = run tests and check that diff from main is covered


### PR DESCRIPTION
Allows for easier exclusion by downstream integrators. Ref jaraco/skeleton#138
