### PR TITLE
Add `--fix`  flag to ruff pre-commit hook for automatic suggestion of fixes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,5 +3,5 @@ repos:
   rev: v0.5.6
   hooks:
   - id: ruff
-    args: [--fix]
+    args: [--fix, --unsafe-fixes]
   - id: ruff-format

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,4 +3,5 @@ repos:
   rev: v0.5.6
   hooks:
   - id: ruff
+    args: [--fix]
   - id: ruff-format


### PR DESCRIPTION
This is documented in https://github.com/astral-sh/ruff-pre-commit?tab=readme-ov-file#using-ruff-with-pre-commit and should be safe to apply, because it requires the developer to "manually approve" the suggested changes via `git add`.