### PR TITLE
`disable_error_code = import-untyped` in mypy.ini

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -13,6 +13,6 @@ explicit_package_bases = True
 disable_error_code =
 	# Disabled due to many false-positives
 	overload-overlap,
-	# Enable import-untyped if you'd like to be notified about using untyped dependencies or missing stubs packages
-	# You can leave it disabled if your package isn't publicly typed / `py.typed`
+	# Disable import-untyped to avoid widespread failures. Remove when safe or when
+	# specific exclusions supersede this broad setting.
 	import-untyped,

--- a/mypy.ini
+++ b/mypy.ini
@@ -10,5 +10,9 @@ enable_error_code = ignore-without-code
 # Support namespace packages per https://github.com/python/mypy/issues/14057
 explicit_package_bases = True
 
-# Disable overload-overlap due to many false-positives
-disable_error_code = overload-overlap
+disable_error_code =
+	# Disabled due to many false-positives
+	overload-overlap,
+	# Enable import-untyped if you'd like to be notified about using untyped dependencies or missing stubs packages
+	# You can leave it disabled if your package isn't publicly typed / `py.typed`
+	import-untyped,


### PR DESCRIPTION
@jaraco  This is a global solution I suggested to reduce a lot of churn and time-consuming changes left as mentioned in https://github.com/jaraco/skeleton/pull/136#issuecomment-2303511967

Projects that already started doing:
```ini
[mypy-*.*]
ignore_missing_imports = True
```
can keep those entries exactly the way they already are w/o issue.

Projects that have yet to identify their untyped dependencies will see a lot less sudden type errors.

This is directly related to https://github.com/jaraco/skeleton/issues/98#issuecomment-1839814825