### PR TITLE
Remove extra line after imports in conf.py

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-
 extensions = [
     'sphinx.ext.autodoc',
     'jaraco.packaging.sphinx',


### PR DESCRIPTION
This change fixes an incompatibility (and source of merge conflicts) with projects using Ruff/isort.

I could add the `I` (https://docs.astral.sh/ruff/rules/#isort-i) category to the Ruff configs (see example from https://github.com/pypa/setuptools/blob/962835d068af4d993f2195e7a6ffd4f70548b9f4/ruff.toml#L60-L62 ). But it would create more conflicts with ongoing https://github.com/jaraco/skeleton/issues/143 .
But at the same time, a lot of those PRs already have conflicts from changes in `mypy.ini` and `conf.py`, and import-related conflicts are easy to fix (accept both + rerun fixer). So maybe now's not a bad time to add it before I fix conflicts.