### PR TITLE
Bump pre-commit hook for ruff to avoid clashes with latest version of `ruff`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.5.6
+  rev: v0.7.1
   hooks:
   - id: ruff
     args: [--fix, --unsafe-fixes]


### PR DESCRIPTION
Closes #149. 