### PR TITLE
Fix `ruff.toml`

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -1,5 +1,5 @@
 # include pyproject.toml for requires-python (workaround astral-sh/ruff#10299)
-include = "pyproject.toml"
+include = ["pyproject.toml"]
 
 [lint]
 extend-select = [


### PR DESCRIPTION
Closes #152.


Ruff docs use a TOML array the configuration field: https://docs.astral.sh/ruff/configuration/#default-inclusions.