### PR TITLE
Alternative workaround for `ruff` (astral-sh/ruff/#10299)

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -1,5 +1,5 @@
-# include pyproject.toml for requires-python (workaround astral-sh/ruff#10299)
-include = "pyproject.toml"
+# workaround astral-sh/ruff#10299 (currently ignoring requires-python from metadata)
+target-version = "py39" # Target the oldest supported Python version
 
 [lint]
 extend-select = [


### PR DESCRIPTION
As pointed out in https://github.com/pypa/setuptools/pull/4718#issuecomment-2448099867 and  https://github.com/astral-sh/ruff/issues/10299#issuecomment-2448131333, including `pyproject.toml` in `ruff.toml` does not look like a good workaround for astral-sh/ruff#10299, since it prevents `ruff` from detecting and updating version related code branches.

This PR implements @Avasam proposal for a temporary workaround. Hopefully `ruff`'s team can address the issue before we need to bump the min version of Python to 3.10.


Alternative to #153. Closes #152.  