### PR TITLE
Consistent import sorting (isort)

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -3,9 +3,10 @@ extend = "pyproject.toml"
 
 [lint]
 extend-select = [
-	"C901",
-	"PERF401",
-	"W",
+	"C901", # complex-structure
+	"I", # isort
+	"PERF401", # manual-list-comprehension
+	"W", # pycodestyle Warning
 ]
 ignore = [
 	# https://docs.astral.sh/ruff/formatter/#conflicting-lint-rules
@@ -24,6 +25,10 @@ ignore = [
 	"ISC001",
 	"ISC002",
 ]
+
+[lint.isort]
+combine-as-imports = true
+split-on-trailing-comma = false
 
 [format]
 # Enable preview to get hugged parenthesis unwrapping and other nice surprises

--- a/ruff.toml
+++ b/ruff.toml
@@ -49,10 +49,6 @@ ignore = [
  	# local
 ]
 
-[lint.isort]
-combine-as-imports = true
-split-on-trailing-comma = false
-
 [format]
 # Enable preview to get hugged parenthesis unwrapping and other nice surprises
 # See https://github.com/jaraco/skeleton/pull/133#issuecomment-2239538373


### PR DESCRIPTION
This PR implements consistent import sorting for skeleton based projects.
The configurations are the same as setuptools' and typeshed's.
`combine-as-imports = true` for concise `as` imports for projects without deviating from the skeleton (ref https://github.com/pypa/distutils/pull/315/commits/fc15d4575aec0c4adeec367c777bac3b642bdc8a)

This is all safely autofixable