### PR TITLE
Enable ruff rules ISC001/ISC002

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -43,8 +43,6 @@ ignore = [
 	"Q003",
 	"COM812",
 	"COM819",
-	"ISC001",
-	"ISC002",
 
  	# local
 ]


### PR DESCRIPTION
Starting with ruff 0.9.1, they are compatible with the ruff formatter when used together.

> #### [Conflicting lint rules](https://docs.astral.sh/ruff/formatter/#conflicting-lint-rules)
> [...]
> When using Ruff as a formatter, we recommend avoiding the following lint rules:
> [...]
> [`multi-line-implicit-string-concatenation`](https://docs.astral.sh/ruff/rules/multi-line-implicit-string-concatenation/) (`ISC002`) if used without `ISC001` and `flake8-implicit-str-concat.allow-multiline = false`
