### PR TITLE
Fix new mandatory configuration field for RTD

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -5,6 +5,9 @@ python:
     extra_requirements:
       - doc
 
+sphinx:
+  configuration: docs/conf.py
+
 # required boilerplate readthedocs/readthedocs.org#10401
 build:
   os: ubuntu-lts-latest


### PR DESCRIPTION
This field is now required and prevents the build from running if absent.

Details in
https://about.readthedocs.com/blog/2024/12/deprecate-config-files-without-sphinx-or-mkdocs-config/

The same change in setuptools seems to fix the CI problem: https://github.com/pypa/setuptools/pull/4812