### PR TITLE
Select Ruff rules for modern type annotations

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -6,6 +6,18 @@ extend-select = [
 	"C901",
 	"PERF401",
 	"W",
+ 
+ 	# Ensure modern type annotation syntax and best practices
+	# Not including those covered by type-checkers or exclusive to Python 3.11+
+	"FA", # flake8-future-annotations
+	"F404", # late-future-import
+	"PYI", # flake8-pyi
+	"UP006", # non-pep585-annotation
+	"UP007", # non-pep604-annotation
+	"UP010", # unnecessary-future-import
+	"UP035", # deprecated-import
+	"UP037", # quoted-annotation
+	"UP043", # unnecessary-default-type-args
 ]
 ignore = [
 	# https://docs.astral.sh/ruff/formatter/#conflicting-lint-rules


### PR DESCRIPTION
Ensure modern type annotation syntax and best practices Not including those covered by type-checkers or exclusive to Python 3.11+

Not including rules currently in preview either.

These are the same set of rules I have in pywin32 as of https://github.com/mhammond/pywin32/pull/2458

setuptools has all the same rules enabled (except it also includes the `UP` group directly)

Solves https://github.com/jaraco/jaraco.context/issues/11