### PR TITLE
Remove extra spaces in ruff.toml

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -4,13 +4,13 @@ extend = "pyproject.toml"
 [lint]
 extend-select = [
 	# upstream
- 
+
 	"C901", # complex-structure
 	"I", # isort
 	"PERF401", # manual-list-comprehension
 	"W", # pycodestyle Warning
- 
- 	# Ensure modern type annotation syntax and best practices
+
+	# Ensure modern type annotation syntax and best practices
 	# Not including those covered by type-checkers or exclusive to Python 3.11+
 	"FA", # flake8-future-annotations
 	"F404", # late-future-import
@@ -26,7 +26,7 @@ extend-select = [
 ]
 ignore = [
 	# upstream
- 
+
 	# Typeshed rejects complex or non-literal defaults for maintenance and testing reasons,
 	# irrelevant to this project.
 	"PYI011", # typed-argument-default-in-stub
@@ -44,7 +44,7 @@ ignore = [
 	"COM812",
 	"COM819",
 
- 	# local
+	# local
 ]
 
 [format]


### PR DESCRIPTION
Looks like these slipped in. No need to redeploy everywhere after merging this. It doesn't break anything. Just reducing further incidental changes like in https://github.com/pypa/setuptools/pull/4857#discussion_r1973815406