### PR TITLE
Standalone ruff checks + Automatically detect requires-python

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,6 +30,15 @@ env:
 
 
 jobs:
+  ruff:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/ruff-action@v3
+      - run: ruff format --check --diff
+        # Show formatting issues even if the "check" step failed
+        if: ${{ !cancelled() }}
+
   test:
     strategy:
       # https://blog.jaraco.com/efficient-use-of-ci-resources/
@@ -96,13 +105,11 @@ jobs:
 
   check:  # This job does nothing and is only used for the branch protection
     if: always()
-
     needs:
-    - test
-    - collateral
-
+      - ruff
+      - test
+      - collateral
     runs-on: ubuntu-latest
-
     steps:
     - name: Decide whether the needed jobs succeeded or failed
       uses: re-actors/alls-green@release/v1

--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,7 @@
    :target: https://github.com/PROJECT_PATH/actions?query=workflow%3A%22tests%22
    :alt: tests
 
-.. image:: https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/charliermarsh/ruff/main/assets/badge/v2.json
+.. image:: https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json
     :target: https://github.com/astral-sh/ruff
     :alt: Ruff
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,9 +43,13 @@ doc = [
 	# local
 ]
 
+ruff = [
+	# Get requires-python from pyproject.toml automatically astral-sh/ruff#16319
+	"ruff >= 0.11.0",
+]
+
 check = [
 	"pytest-checkdocs >= 2.4",
-	"pytest-ruff >= 0.2.1; sys_platform != 'cygwin'",
 ]
 
 cover = [

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,6 +1,3 @@
-# extend pyproject.toml for requires-python (workaround astral-sh/ruff#10299)
-extend = "pyproject.toml"
-
 [lint]
 extend-select = [
 	# upstream


### PR DESCRIPTION
It recently crossed my mind that you don't need to run Ruff on every os and Python version. In fact, you don't even need to have Python installed to run Ruff !

Running it through pytest everytime seems not only wasteful, but has caused issues (between version desync, huge logs spam, and not as clear errors)

`astral-sh/ruff-action@v3` automatically finds the version of Ruff to install and run from looking at a `pyproject.toml`'s `project.optional-dependencies` and `dependency-groups`.

Since no other test uses Ruff, no need to install it, so I split it into its own extra.

This PR also bumps Ruff's lower bound to 0.11, where the detection of `requires-python` is automated.