### PR TITLE
Remove deprecated license classifier (PEP 639)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,6 @@ readme = "README.rst"
 classifiers = [
 	"Development Status :: 5 - Production/Stable",
 	"Intended Audience :: Developers",
-	"License :: OSI Approved :: MIT License",
 	"Programming Language :: Python :: 3",
 	"Programming Language :: Python :: 3 :: Only",
 ]


### PR DESCRIPTION
License classifiers are deprecated post-PEP 639.
With the implementation of the PEP now this causes a warning,
so this PR removes the classifier.


Since setuptools automatically picks up `LICENSE*` files, the license information is already included in the distribution.

A possible additional step is to add a SPDX license expression like `license = "MIT"` to the `[project]` table in PyPI.

This PR does not implement this additional step because my understanding is that not all projects can derive accurate SPDX license expressions. For example, `setuptools`, as far as I understand, would need a very [complex compound SPDX expression](https://spdx.github.io/spdx-spec/v2.3/SPDX-license-expressions/#d43-conjunctive-and-operator) to cope with the vendored packages: `MIT AND APACHE-2 AND LGPL-3.0-or-later AND PSF-2.0...`. Moreover this expression would need reviewing/updating everytime the vendored dependencies are updated.