### PR TITLE
Revert "Python 3 is the default nowadays (jaraco/skeleton#173)"

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -86,6 +86,8 @@ jobs:
           fetch-depth: 0
       - name: Setup Python
         uses: actions/setup-python@v5
+        with:
+          python-version: 3.x
       - name: Install tox
         run: python -m pip install tox
       - name: Eval ${{ matrix.job }}
@@ -118,6 +120,8 @@ jobs:
       - uses: actions/checkout@v4
       - name: Setup Python
         uses: actions/setup-python@v5
+        with:
+          python-version: 3.x
       - name: Install tox
         run: python -m pip install tox
       - name: Run


### PR DESCRIPTION
This reverts commit 867396152fcb99055795120750dfda53f85bb414 (#173).

Removing `python-version` falls back on the Python bundled with the runner, making `actions/setup-python` a no-op. Here, the maintainer prefers using the latest release of Python 3. This is what `3.x` means: use the latest release of Python 3.

