### PR TITLE
Log filenames when running pytest-mypy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,12 +58,12 @@ cover = [
 ]
 
 enabler = [
-	"pytest-enabler >= 2.2",
+	"pytest-enabler >= 3.4",
 ]
 
 type = [
 	# upstream
-	"pytest-mypy",
+	"pytest-mypy >= 1.0.1",
 
 	# local
 ]


### PR DESCRIPTION
Reference: https://github.com/realpython/pytest-mypy/pull/193 and https://github.com/jaraco/pytest-enabler/pull/20
Closes https://github.com/pypa/setuptools/pull/4502

Because there's no concept of peer dependencies, if you happen to have `pytest-enabler >= 3.4` but `pytest-mypy < 1.0.1`, you'll get errors since an unknown parameter will be passed to pytest. So I bumped both pins.

If you don't mind / don't care about this possible issue. This PR can simply be closed as dependencies should get updated next time the pip cache is busted for whatever CI it's running.