### PR TITLE
Update pre-commit Ruff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.9.9
+  rev: v0.12.0
   hooks:
   - id: ruff
     args: [--fix, --unsafe-fixes]


### PR DESCRIPTION
This is intended to close #180.

The update is required to avoid conflicts between `pytest-ruff` and `pre-commit`'s `ruff` versions.

I understand that `.pre-commit-config.yaml` is a bit controversial. I don't have a strong opinion about it. So another alternative would be also removing. Related to https://github.com/jaraco/skeleton/issues/109#issuecomment-2676534591.