### PR TITLE
Expect modern ruff and simplify configs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,8 @@ doc = [
 check = [
 	"pytest-checkdocs >= 2.14",
 	"pytest-ruff >= 0.2.1; sys_platform != 'cygwin'",
+	# Deprecated rules must now be selected by exact rule code
+	"ruff >= 0.13; sys_platform != 'cygwin'",
 ]
 
 cover = [
@@ -64,7 +66,7 @@ enabler = [
 type = [
 	# upstream
 	
-    # Exclude PyPy from type checks (python/mypy#20454 jaraco/skeleton#187)
+	# Exclude PyPy from type checks (python/mypy#20454 jaraco/skeleton#187)
 	"pytest-mypy >= 1.0.1; platform_python_implementation != 'PyPy'",
 
 	# local

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,8 +51,6 @@ doc = [
 check = [
 	"pytest-checkdocs >= 2.14",
 	"pytest-ruff >= 0.2.1; sys_platform != 'cygwin'",
-	# Deprecated rules must now be selected by exact rule code
-	"ruff >= 0.13; sys_platform != 'cygwin'",
 ]
 
 cover = [

--- a/ruff.toml
+++ b/ruff.toml
@@ -5,38 +5,27 @@ extend-select = [
 	"C901", # complex-structure
 	"I", # isort
 	"PERF401", # manual-list-comprehension
+	"UP", # pyupgrade (Code modernization for strings, annotations, conditions, ...)
 
 	# Ensure modern type annotation syntax and best practices
 	# Not including those covered by type-checkers or exclusive to Python 3.11+
 	"FA", # flake8-future-annotations
 	"F404", # late-future-import
 	"PYI", # flake8-pyi
-	"UP006", # non-pep585-annotation
-	"UP007", # non-pep604-annotation
-	"UP010", # unnecessary-future-import
-	"UP035", # deprecated-import
-	"UP037", # quoted-annotation
-	"UP043", # unnecessary-default-type-args
 
 	# local
 ]
 ignore = [
 	# upstream
+	"UP015", # redundant-open-modes, explicit is preferred
 
 	# Typeshed rejects complex or non-literal defaults for maintenance and testing reasons,
 	# irrelevant to this project.
 	"PYI011", # typed-argument-default-in-stub
 	# https://docs.astral.sh/ruff/formatter/#conflicting-lint-rules
 	"W191",
-	"E111",
-	"E114",
-	"E117",
 	"D206",
 	"D300",
-	"Q000",
-	"Q001",
-	"Q002",
-	"Q003",
 	"COM812",
 	"COM819",
 


### PR DESCRIPTION
Same changes as for https://github.com/pypa/setuptools/pull/4886

Do test on some repos with lots of string formatting, [f-string (UP032)](https://docs.astral.sh/ruff/rules/f-string/#f-string-up032) is not necessarily a rule you may want to enforce all the time.

Reduced the `conflicting-lint-rules` section to only the codes for which you'd enable the entire group in parallel. Because the base `E` and `F` rules in default `select` are already non-conflicting and we use `extend-select` to start from said base.