### PR TITLE
Don't install (nor run) mypy on PyPy (librt build failures)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,8 +63,8 @@ enabler = [
 
 type = [
 	# upstream
-	# static type checking doesn't need to be run on PyPy.
-	# This also prevents sudden unexpected failure from incompatibilities
+	
+    # Exclude PyPy from type checks (python/mypy#20454 jaraco/skeleton#187)
 	"pytest-mypy >= 1.0.1; platform_python_implementation != 'PyPy'",
 
 	# local


### PR DESCRIPTION
Static type checking doesn't need to be run on PyPy.
This saves a bit of time and also prevents sudden unexpected failure from incompatibilities.

The latest reason is that librt, a new mypy dependency used for their new cache, doesn't build on PyPy. 

But it's not the first time mypy can't be run on PyPy and it's not like running static type checking on PyPy actually brings anything other than wasting time. So I used a more generalized explanation so we're not tempted to remove the install exclusion.