### PR TITLE
Bump `pytest-checkdocs` to `>= 2.14` to resolve deprecation warnings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,6 @@ doc = [
 ]
 
 check = [
-	# Satisfy deprecation warning introduced in docutils 0.22
 	"pytest-checkdocs >= 2.14",
 	"pytest-ruff >= 0.2.1; sys_platform != 'cygwin'",
 ]


### PR DESCRIPTION
Unblocks many downstream CIs failing due to deprecation warnings.

`pytest-checkdocs` is also now fully typed and marked as such, but I don't see any linked issue downstream that was depending on that.