### PR TITLE
Fix CI warning

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -20,7 +20,7 @@ deps =
 	diff-cover
 commands =
 	pytest {posargs} --cov-report xml
-	diff-cover coverage.xml --compare-branch=origin/main --html-report diffcov.html
+	diff-cover coverage.xml --compare-branch=origin/main --format html:diffcov.html
 	diff-cover coverage.xml --compare-branch=origin/main --fail-under=100
 
 [testenv:docs]


### PR DESCRIPTION
```
UserWarning: The --html-report option is deprecated. Use --format html:diffcov.html instead.
```