### PR TITLE
mypy: allow_redefinition = true

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,6 +1,8 @@
 [mypy]
 # Is the project well-typed?
 strict = False
+# More lenient, but still safe, reassignments
+allow_redefinition = true
 
 # Early opt-in even when strict = False
 warn_unused_ignores = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ enabler = [
 type = [
 	# upstream
 	
-    # Exclude PyPy from type checks (python/mypy#20454 jaraco/skeleton#187)
+	# Exclude PyPy from type checks (python/mypy#20454 jaraco/skeleton#187)
 	"pytest-mypy >= 1.0.1; platform_python_implementation != 'PyPy'",
 
 	# local
@@ -72,7 +72,3 @@ type = [
 
 
 [tool.setuptools_scm]
-
-
-[tool.pytest-enabler.mypy]
-# Disabled due to jaraco/skeleton#143


### PR DESCRIPTION
Same change as [pypa/distutils@`aacbb3d` (#368)](https://github.com/pypa/distutils/pull/368/changes/aacbb3d0541c75e38e5f11523a1d6a4c446f08b2)

This *requires* the option [local_partial_types](https://mypy.readthedocs.io/en/stable/config_file.html#confval-local_partial_types) to also be enabled, but that's default since mypy 2.0